### PR TITLE
Bugfix: login-signup endpoints can't find the User model

### DIFF
--- a/practice-app/backend/controllers/login-signup.js
+++ b/practice-app/backend/controllers/login-signup.js
@@ -1,4 +1,5 @@
 const bcrypt = require('bcryptjs');
+let { User } = require('./../models/user.js');  // The connection to the User model in the database
 
 /*
   Post method for signup.

--- a/practice-app/backend/routes/login-signup.js
+++ b/practice-app/backend/routes/login-signup.js
@@ -2,8 +2,6 @@ const express = require('express');
 const router = express.Router();
 const authControllers = require('../controllers/login-signup')
 
-let { User } = require('./../models/user.js');  // The connection to the User model in the database
-
 /*
   Post endpoint for signup.
   Check controller function for more detail


### PR DESCRIPTION
When separating controllers from routes, the User model was left in routes and the controller couldn't use it. Solved by moving the require statement to tthe controller.