### PR TITLE
add extra fields and pagination to the response data in events

### DIFF
--- a/app/backend/controllers/events.js
+++ b/app/backend/controllers/events.js
@@ -17,13 +17,13 @@ module.exports.getEvents = async (request, response) => {
   // undefined variables are the projections over the collection
   try {
     if(Country && Importance){
-      events = await Event.find({ Country, Importance }, undefined, {skip, limit})
+      events = await Event.find({ Country, Importance }, undefined, {skip, limit}).sort({Date: -1})
     } else if(Country && !Importance){
-      events = await Event.find({ Country }, undefined, {skip, limit})
+      events = await Event.find({ Country }, undefined, {skip, limit}).sort({Date: -1})
     } else if(!Country && Importance){
-      events = await Event.find({ Importance }, undefined, {skip, limit})
+      events = await Event.find({ Importance }, undefined, {skip, limit}).sort({Date: -1})
     } else {
-      events = await Event.find({ }, undefined, {skip, limit})
+      events = await Event.find({ }, undefined, {skip, limit}).sort({Date: -1})
     }
     const totalNumberOfEvents = await Event.countDocuments({})
     return response.send({

--- a/app/backend/controllers/events.js
+++ b/app/backend/controllers/events.js
@@ -12,22 +12,23 @@ module.exports.getEvents = async (request, response) => {
   */
   let Country = request.query.country
   let Importance = request.query.importance
-  const skip = (parseInt(request.query.page || '1') - 1) * 10
+  const limit = parseInt(request.query.limit || 10)
+  const skip = (parseInt(request.query.page || 1) - 1) * limit
   // undefined variables are the projections over the collection
   try {
     if(Country && Importance){
-      events = await Event.find({ Country, Importance }, undefined, {skip, limit: 10})
+      events = await Event.find({ Country, Importance }, undefined, {skip, limit})
     } else if(Country && !Importance){
-      events = await Event.find({ Country }, undefined, {skip, limit: 10})
+      events = await Event.find({ Country }, undefined, {skip, limit})
     } else if(!Country && Importance){
-      events = await Event.find({ Importance }, undefined, {skip, limit: 10})
+      events = await Event.find({ Importance }, undefined, {skip, limit})
     } else {
-      events = await Event.find({ }, undefined, {skip, limit: 10})
+      events = await Event.find({ }, undefined, {skip, limit})
     }
     const totalNumberOfEvents = await Event.countDocuments({})
     return response.send({
       totalNumberOfEvents,
-      totalNumberOfPages: Math.ceil(totalNumberOfEvents / 10),
+      totalNumberOfPages: Math.ceil(totalNumberOfEvents / limit),
       eventsInPage: events.length,
       events
     }); 

--- a/app/backend/controllers/events.js
+++ b/app/backend/controllers/events.js
@@ -12,21 +12,28 @@ module.exports.getEvents = async (request, response) => {
   */
   let Country = request.query.country
   let Importance = request.query.importance
-
-  if(Country && Importance){
-    events = await Event.find({ Country, Importance })
-  } else if(Country && !Importance){
-    events = await Event.find({ Country })
-  } else if(!Country && Importance){
-    events = await Event.find({ Importance })
-  } else {
-    events = await Event.find({ })
+  const skip = (parseInt(request.query.page || '1') - 1) * 10
+  // undefined variables are the projections over the collection
+  try {
+    if(Country && Importance){
+      events = await Event.find({ Country, Importance }, undefined, {skip, limit: 10})
+    } else if(Country && !Importance){
+      events = await Event.find({ Country }, undefined, {skip, limit: 10})
+    } else if(!Country && Importance){
+      events = await Event.find({ Importance }, undefined, {skip, limit: 10})
+    } else {
+      events = await Event.find({ }, undefined, {skip, limit: 10})
+    }
+    const totalNumberOfEvents = await Event.countDocuments({})
+    return response.send({
+      totalNumberOfEvents,
+      totalNumberOfPages: Math.ceil(totalNumberOfEvents / 10),
+      eventsInPage: events.length,
+      events
+    }); 
+  } catch(e) {
+    console.log(e)
   }
-
-  return response.send({
-    totalNumberOfEvents: events.length,
-    events
-  }); 
 }
 
 /*


### PR DESCRIPTION
Added `totalNumberOfPages` and `eventsInPage`, updated `totalNumberOfEvents` fields in the response data. The endpoints returns 10 events max per page.