### PR TITLE
Backend bugfix comment detail cannot read about field

### DIFF
--- a/app/backend/controllers/comments.js
+++ b/app/backend/controllers/comments.js
@@ -47,8 +47,8 @@ module.exports.getComment = async (request, response) => {
 module.exports.deleteComment = async (request, response) => {
   let Comment = request.models['Comment']
 
-  Comment.deleteOne({ _id : request.params['id'], userId : request.session['user']._id, about : request.body.about.toUpperCase() }, (err, results) => {
-    if(err){
+  Comment.deleteOne({ _id: request.params['id'], userId: request.session['user']._id, about: request.params.about.toUpperCase() }, (err, results) => {
+    if (err) {
       return response.status(404).send({
         errmsg: "Failed."
       })

--- a/app/backend/controllers/comments.js
+++ b/app/backend/controllers/comments.js
@@ -29,7 +29,7 @@ module.exports.postComment = async (request, response) => {
 module.exports.getComment = async (request, response) => {
   let Comment = request.models['Comment']
 
-  comment = await Comment.findOne({ _id : request.params['id'], about : request.body.about.toUpperCase() });
+  comment = await Comment.findOne({ _id: request.params['id'], about: request.params.about.toUpperCase() });
 
   if(comment){
     return response.send(comment)

--- a/app/backend/routes/comments.js
+++ b/app/backend/routes/comments.js
@@ -26,6 +26,6 @@ router.get('/:about/:id', modelBinder(Comment, 'Comment'), commentController.get
   Delete endpoint for comment page.
   Check controller function for more detail
 */
-router.delete('/:id', [isAuthenticated, modelBinder(Comment, 'Comment')], commentController.deleteComment)
+router.delete('/:about/:id', [isAuthenticated, modelBinder(Comment, 'Comment')], commentController.deleteComment)
 
 module.exports = router

--- a/app/backend/routes/comments.js
+++ b/app/backend/routes/comments.js
@@ -20,7 +20,7 @@ router.post('/', [
   Get endpoint for comment page.
   Check controller function for more detail
 */
-router.get('/:id', modelBinder(Comment, 'Comment'), commentController.getComment)
+router.get('/:about/:id', modelBinder(Comment, 'Comment'), commentController.getComment)
 
 /*
   Delete endpoint for comment page.


### PR DESCRIPTION
Comment detail retrieval and comment deletion endpoints weren't functioning properly and necessary fixes are implemented. Updated endpoint URL's will be added to the documentation.