### PR TITLE
make results unique on search

### DIFF
--- a/app/backend/controllers/search.js
+++ b/app/backend/controllers/search.js
@@ -19,11 +19,46 @@ module.exports.search = async (req, res, next) => {
 
     // searches for every word in the query string
     let users = terms.flatMap(term => filterData(usersData, ['name', 'surname', 'location'],term))
+    users = users.reduce((acc, value) => {
+        if(value._id in acc) {
+            return acc
+        } else {
+            acc[value._id] = value
+            return acc
+        }
+    }, {})
+    users = Object.values(users)
     users = Array.from(new Set(users)).sort((a, b) => eval(b.predictionRate) - eval(a.predictionRate))
-    const events = terms.flatMap(term => filterData(eventsData, ['Country', 'Catogory', 'Event'], term))
-    const tradingEq = terms.flatMap(term => filterData(tradingEqData, ['from', 'fromName', 'to', 'toName'], term))
-    const articles = terms.flatMap(term => filterData(articlesData, ['text', 'title'], term))
-
+    let events = terms.flatMap(term => filterData(eventsData, ['Country', 'Catogory', 'Event'], term))
+    events = events.reduce((acc, value) => {
+        if(value._id in acc) {
+            return acc
+        } else {
+            acc[value._id] = value
+            return acc
+        }
+    }, {})
+    events = Object.values(events)
+    let tradingEq = terms.flatMap(term => filterData(tradingEqData, ['from', 'fromName', 'to', 'toName'], term))
+    tradingEq = tradingEq.reduce((acc, value) => {
+        if(value._id in acc) {
+            return acc
+        } else {
+            acc[value._id] = value
+            return acc
+        }
+    }, {})
+    tradingEq = Object.values(tradingEq)
+    let articles = terms.flatMap(term => filterData(articlesData, ['text', 'title'], term))
+    articles = articles.reduce((acc, value) => {
+        if(value._id in acc) {
+            return acc
+        } else {
+            acc[value._id] = value
+            return acc
+        }
+    }, {})
+    articles = Object.values(articles)
     return res.json({
         users,
         events,


### PR DESCRIPTION
Closes #385.

Our API sometimes results in duplicate entries. Those are filtered now and unique ones are returned to the user.