### PR TITLE
Change semantic search method to search by tagging

### DIFF
--- a/app/backend/controllers/article.js
+++ b/app/backend/controllers/article.js
@@ -1,6 +1,7 @@
 const {findUserArticle} = require('../utils')
 const {findUserComments} = require('../utils')
 const {User} = require('../models/user')
+const axios = require('axios')
   /*
     Get method for articles.
     It returns all articles in database.
@@ -47,7 +48,12 @@ module.exports.postArticle = async (request, response) => {
       userId: request.session['user']._id,
       date: new Date()
     });
-  
+
+    const queryKeyword = request.body.title.split(' ').join('+')
+    let tags = await axios.get(`https://api.datamuse.com/words?max=15&ml=${queryKeyword}`)
+    tags = tags.data.map(el => el.word)
+    article.tags = tags
+
     // Saves the instance into the database, returns any error occured
     article.save()
       .then(doc => {

--- a/app/backend/controllers/search.js
+++ b/app/backend/controllers/search.js
@@ -9,7 +9,7 @@ module.exports.search = async (req, res, next) => {
     let usersData = User.find().select('name surname location predictionRate').sort({predictionRate: -1}).lean()
     let eventsData = Event.find().select('Country CalendarId Date Catogory Event Importance').sort({Importance: -1}).lean()
     let tradingEqData = CurrentTradingEquipment.find().select('from fromName to toName rate').lean()
-    let articlesData = Article.find().select('text title').lean()
+    let articlesData = Article.find().select('text title tags').lean()
 
 
     usersData = await usersData

--- a/app/backend/models/article.js
+++ b/app/backend/models/article.js
@@ -17,6 +17,10 @@ let Article = mongoose.model('Article', {
       require: true
   },
 
+  tags: {
+    type: [String]
+  },
+  
   date:{
     type: Date,
     require: true

--- a/app/backend/utils.js
+++ b/app/backend/utils.js
@@ -984,25 +984,21 @@ function js_yyyy_mm_dd_hh_mm_ss () {
   return year + "-" + month + "-" + day + " " + hour + ":" + minute + ":" + second;
 }
 
-const compareText = async (text1, text2) => {
-  return await axios({
-    "method":"GET",
-    "url":"https://twinword-text-similarity-v1.p.rapidapi.com/similarity/",
-    "headers": {
-      "content-type": "application/octet-stream",
-      "x-rapidapi-host": "twinword-text-similarity-v1.p.rapidapi.com",
-      "x-rapidapi-key": rapidAPIKey
-    },
-    "params": {
-      text1,
-      text2
-    }
-  })
-}
-
-module.exports.compareText = compareText
-
 module.exports.filterArticleTitles = async (articles, terms) => {
+  const queryKeyword = terms.split(' ').join('+')
+  let searchTags = await axios.get(`https://api.datamuse.com/words?max=15&ml=${queryKeyword}`)
+  searchTags = searchTags.data.map(el => el.word)
+
+  return articles.filter(({tags}) => {
+    const matched = searchTags.filter(tag => {
+      if(tags) {
+        return tags.indexOf(tag) > -1
+      } else {
+        return false
+      }
+    }).length > 0
+    return matched
+  })
   const similarities = await Promise.all(articles.map(article => {
     return axios({
       "method":"GET",

--- a/app/backend/utils.js
+++ b/app/backend/utils.js
@@ -999,25 +999,4 @@ module.exports.filterArticleTitles = async (articles, terms) => {
     }).length > 0
     return matched
   })
-  const similarities = await Promise.all(articles.map(article => {
-    return axios({
-      "method":"GET",
-      "url":"https://twinword-text-similarity-v1.p.rapidapi.com/similarity/",
-      "headers": {
-        "content-type": "application/octet-stream",
-        "x-rapidapi-host": "twinword-text-similarity-v1.p.rapidapi.com",
-        "x-rapidapi-key": rapidAPIKey
-      },
-      "params": {
-        text1: article.title,
-        text2: terms
-      }
-    }).catch(err => {
-      console.log(err)
-    })
-  }))
-
-  return articles.filter((_, index) => {
-    return similarities[index].data.similarity > 0.1
-  })
 }


### PR DESCRIPTION
I've added tagging to articles by their titles. Now, when searching, the articles are filtered by tag matches. Search terms are tagged as well, and any tag between article tags and search terms' tags matches, that article is included in the search result.